### PR TITLE
always_run will be deprecated, use check_mode = no

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Get installed version of Apache.
   shell: "{{ apache_daemon_path }}{{ apache_daemon }} -v"
   changed_when: false
-  always_run: yes
+  check_mode: no
   register: _apache_version
 
 - name: Create apache_version variable.


### PR DESCRIPTION
```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4
```